### PR TITLE
Fix `SkyDropdownModule` to import `SkyPopoversResourcesModule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.0-alpha.1 (2019-06-20)
+
+- Fixed `SkyDropdownModule` to properly import `SkyPopoversResourcesModule`.
+
 # 3.2.0-alpha.0 (2019-06-20)
 
 - Built library against the `fix-umd-modules` branch in Builder to try out a new AoT implementation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.0-alpha.2 (2019-06-20)
+
+- Built library against `@skyux-sdk/builder@3.6.7` to verify existing implementation of AoT does not work.
+
 # 3.2.0-alpha.1 (2019-06-20)
 
 - Fixed `SkyDropdownModule` to properly import `SkyPopoversResourcesModule`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,3 @@
-# 3.2.0-alpha.2 (2019-06-20)
-
-- Built library against `@skyux-sdk/builder@3.6.7` to verify existing implementation of AoT does not work.
-
-# 3.2.0-alpha.1 (2019-06-20)
-
-- Fixed `SkyDropdownModule` to properly import `SkyPopoversResourcesModule`.
-
-# 3.2.0-alpha.0 (2019-06-20)
-
-- Built library against the `fix-umd-modules` branch in Builder to try out a new AoT implementation.
-
 # 3.1.0 (2019-06-20)
 
 - Updated development dependencies to support `@skyux-sdk/builder@3.6.7`. [#17](https://github.com/blackbaud/skyux-popovers/pull/17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.0-alpha.0 (2019-06-20)
+
+- Built library against the `fix-umd-modules` branch in Builder to try out a new AoT implementation.
+
 # 3.1.0 (2019-06-20)
 
 - Updated development dependencies to support `@skyux-sdk/builder@3.6.7`. [#17](https://github.com/blackbaud/skyux-popovers/pull/17)

--- a/package-lock.json
+++ b/package-lock.json
@@ -507,8 +507,9 @@
       "dev": true
     },
     "@skyux-sdk/builder": {
-      "version": "github:blackbaud/skyux-sdk-builder#93bfe52a001cef2228b8536c6e27bdfd0fb77408",
-      "from": "github:blackbaud/skyux-sdk-builder#fix-umd-modules",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@skyux-sdk/builder/-/builder-3.6.7.tgz",
+      "integrity": "sha512-dQZ5yxFCpZaRTubBxayI4pJZLbuoks71m9tgob/aUL0eqOHguTftl21G2EE6mhctFCbuRzayZbVNXjLbn3wHVA==",
       "dev": true,
       "requires": {
         "@angular-devkit/build-optimizer": "0.13.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/popovers",
-  "version": "3.1.0",
+  "version": "3.2.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/popovers",
-  "version": "3.2.0-alpha.1",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -967,9 +967,9 @@
       "dev": true
     },
     "@skyux/popovers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@skyux/popovers/-/popovers-3.0.0.tgz",
-      "integrity": "sha512-ChO2ffXlpdvdjtsGvj8hRejDkV8RYbWTvOuNr1H9ZzczSFy5mm63qx+dAnA0faQoKReHfYZ+zhDToGmxsCuQmQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@skyux/popovers/-/popovers-3.1.0.tgz",
+      "integrity": "sha512-VSjujnHSdi3tlxuBMeE69orNtYAkbkfcJwlh+bg4eD/aUJ6NfU4eXY7pEOHI9lGZ6BUeRSqG8O9Chj47MjpqDw==",
       "dev": true
     },
     "@skyux/router": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -507,9 +507,8 @@
       "dev": true
     },
     "@skyux-sdk/builder": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/@skyux-sdk/builder/-/builder-3.6.7.tgz",
-      "integrity": "sha512-dQZ5yxFCpZaRTubBxayI4pJZLbuoks71m9tgob/aUL0eqOHguTftl21G2EE6mhctFCbuRzayZbVNXjLbn3wHVA==",
+      "version": "github:blackbaud/skyux-sdk-builder#93bfe52a001cef2228b8536c6e27bdfd0fb77408",
+      "from": "github:blackbaud/skyux-sdk-builder#fix-umd-modules",
       "dev": true,
       "requires": {
         "@angular-devkit/build-optimizer": "0.13.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/popovers",
-  "version": "3.2.0-alpha.2",
+  "version": "3.1.0",
   "description": "SKY UX Popovers",
   "main": "bundles/bundle.umd.js",
   "module": "index.ts",
@@ -59,7 +59,7 @@
     "@skyux/indicators": "3.0.3",
     "@skyux/modals": "3.0.4",
     "@skyux/omnibar-interop": "3.1.0",
-    "@skyux/popovers": "3.0.0",
+    "@skyux/popovers": "3.1.0",
     "@skyux/router": "3.1.1",
     "@skyux/theme": "3.7.0",
     "@types/core-js": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/popovers",
-  "version": "3.2.0-alpha.1",
+  "version": "3.2.0-alpha.2",
   "description": "SKY UX Popovers",
   "main": "bundles/bundle.umd.js",
   "module": "index.ts",
@@ -46,7 +46,7 @@
     "@blackbaud/auth-client": "2.15.1",
     "@pact-foundation/pact": "8.2.6",
     "@pact-foundation/pact-web": "7.4.0",
-    "@skyux-sdk/builder": "blackbaud/skyux-sdk-builder#fix-umd-modules",
+    "@skyux-sdk/builder": "3.6.7",
     "@skyux-sdk/builder-plugin-skyux": "1.0.0",
     "@skyux-sdk/e2e": "3.1.2",
     "@skyux-sdk/pact": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/popovers",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "description": "SKY UX Popovers",
   "main": "bundles/bundle.umd.js",
   "module": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/popovers",
-  "version": "3.1.0",
+  "version": "3.2.0-alpha.0",
   "description": "SKY UX Popovers",
   "main": "bundles/bundle.umd.js",
   "module": "index.ts",
@@ -46,7 +46,7 @@
     "@blackbaud/auth-client": "2.15.1",
     "@pact-foundation/pact": "8.2.6",
     "@pact-foundation/pact-web": "7.4.0",
-    "@skyux-sdk/builder": "3.6.7",
+    "@skyux-sdk/builder": "blackbaud/skyux-sdk-builder#fix-umd-modules",
     "@skyux-sdk/builder-plugin-skyux": "1.0.0",
     "@skyux-sdk/e2e": "3.1.2",
     "@skyux-sdk/pact": "3.2.1",

--- a/skyuxconfig.json
+++ b/skyuxconfig.json
@@ -6,6 +6,9 @@
   "skyuxModules": [
     "SkyErrorModule"
   ],
+  "moduleAliases": {
+    "@skyux/popovers": "src/app/public"
+  },
   "plugins": [
     "@skyux-sdk/builder-plugin-skyux"
   ],

--- a/src/app/public/modules/dropdown/dropdown-button.component.ts
+++ b/src/app/public/modules/dropdown/dropdown-button.component.ts
@@ -1,4 +1,6 @@
-import { Component } from '@angular/core';
+import {
+  Component
+} from '@angular/core';
 
 @Component({
   selector: 'sky-dropdown-button',

--- a/src/app/public/modules/dropdown/dropdown-menu.component.ts
+++ b/src/app/public/modules/dropdown/dropdown-menu.component.ts
@@ -13,11 +13,19 @@ import {
   QueryList
 } from '@angular/core';
 
-import { Subject } from 'rxjs/Subject';
+import {
+  Subject
+} from 'rxjs/Subject';
+
 import 'rxjs/add/operator/takeUntil';
 
-import { SkyDropdownComponent } from './dropdown.component';
-import { SkyDropdownItemComponent } from './dropdown-item.component';
+import {
+  SkyDropdownComponent
+} from './dropdown.component';
+
+import {
+  SkyDropdownItemComponent
+} from './dropdown-item.component';
 
 import {
   SkyDropdownMenuChange,

--- a/src/app/public/modules/dropdown/dropdown.component.spec.ts
+++ b/src/app/public/modules/dropdown/dropdown.component.spec.ts
@@ -7,17 +7,25 @@ import {
 } from '@angular/core/testing';
 
 import {
+  By
+} from '@angular/platform-browser';
+
+import {
   expect,
   SkyAppTestUtility
 } from '@skyux-sdk/testing';
 
 import {
+  SkyDropdownFixturesModule
+} from './fixtures/dropdown-fixtures.module';
+
+import {
+  DropdownTestComponent
+} from './fixtures/dropdown.component.fixture';
+
+import {
   SkyDropdownMessageType
 } from './types';
-
-import { SkyDropdownFixturesModule } from './fixtures/dropdown-fixtures.module';
-import { DropdownTestComponent } from './fixtures/dropdown.component.fixture';
-import { By } from '@angular/platform-browser';
 
 describe('Dropdown component', () => {
   const activeItemClass = 'sky-dropdown-item-active';

--- a/src/app/public/modules/dropdown/dropdown.component.ts
+++ b/src/app/public/modules/dropdown/dropdown.component.ts
@@ -9,7 +9,18 @@ import {
   ViewChild
 } from '@angular/core';
 
-import { Subject } from 'rxjs/Subject';
+import {
+  SkyWindowRefService
+} from '@skyux/core';
+
+import {
+  SkyLibResourcesService
+} from '@skyux/i18n';
+
+import {
+  Subject
+} from 'rxjs/Subject';
+
 import 'rxjs/add/operator/takeUntil';
 
 import {
@@ -19,15 +30,10 @@ import {
 } from '../popover';
 
 import {
-  SkyWindowRefService
-} from '@skyux/core/modules/window';
-
-import {
   SkyDropdownMessage,
   SkyDropdownMessageType,
   SkyDropdownTriggerType
 } from './types';
-import { SkyLibResourcesService } from '@skyux/i18n';
 
 @Component({
   selector: 'sky-dropdown',

--- a/src/app/public/modules/dropdown/dropdown.module.ts
+++ b/src/app/public/modules/dropdown/dropdown.module.ts
@@ -1,29 +1,39 @@
 import {
-  NgModule
-} from '@angular/core';
-import {
   CommonModule
 } from '@angular/common';
 
 import {
-  SkyWindowRefService
-} from '@skyux/core/modules/window';
+  NgModule
+} from '@angular/core';
+
 import {
-  SkyPopoverModule
-} from '../popover';
+  SkyWindowRefService
+} from '@skyux/core';
+
 import {
   SkyIconModule
-} from '@skyux/indicators/modules/icon';
+} from '@skyux/indicators';
+
+import {
+  SkyPopoverModule
+} from '../popover/popover.module';
+
+import {
+  SkyPopoversResourcesModule
+} from '../shared/popovers-resources.module';
 
 import {
   SkyDropdownButtonComponent
 } from './dropdown-button.component';
+
 import {
   SkyDropdownItemComponent
 } from './dropdown-item.component';
+
 import {
   SkyDropdownMenuComponent
 } from './dropdown-menu.component';
+
 import {
   SkyDropdownComponent
 } from './dropdown.component';
@@ -37,8 +47,9 @@ import {
   ],
   imports: [
     CommonModule,
+    SkyIconModule,
     SkyPopoverModule,
-    SkyIconModule
+    SkyPopoversResourcesModule
   ],
   exports: [
     SkyDropdownButtonComponent,

--- a/src/app/public/modules/dropdown/fixtures/dropdown-fixtures.module.ts
+++ b/src/app/public/modules/dropdown/fixtures/dropdown-fixtures.module.ts
@@ -1,9 +1,19 @@
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import {
+  CommonModule
+} from '@angular/common';
 
-import { SkyDropdownModule } from '../index';
-import { DropdownTestComponent } from './dropdown.component.fixture';
+import {
+  NoopAnimationsModule
+} from '@angular/platform-browser/animations';
+
+import {
+  SkyDropdownModule
+} from '../dropdown.module';
+
+import {
+  DropdownTestComponent
+} from './dropdown.component.fixture';
 
 @NgModule({
   declarations: [

--- a/src/app/public/modules/dropdown/fixtures/dropdown.component.fixture.ts
+++ b/src/app/public/modules/dropdown/fixtures/dropdown.component.fixture.ts
@@ -5,15 +5,22 @@ import {
   ViewChild
 } from '@angular/core';
 
-import { Subject } from 'rxjs/Subject';
+import {
+  Subject
+} from 'rxjs/Subject';
 
 import {
   SkyDropdownMessageType,
   SkyDropdownMessage
 } from '../types';
 
-import { SkyDropdownComponent } from '../dropdown.component';
-import { SkyDropdownMenuComponent } from '../dropdown-menu.component';
+import {
+  SkyDropdownComponent
+} from '../dropdown.component';
+
+import {
+  SkyDropdownMenuComponent
+} from '../dropdown-menu.component';
 
 @Component({
   selector: 'sky-test-cmp',

--- a/src/app/public/modules/dropdown/types/dropdown-menu-change.ts
+++ b/src/app/public/modules/dropdown/types/dropdown-menu-change.ts
@@ -1,4 +1,6 @@
-import { SkyDropdownItemComponent } from '../dropdown-item.component';
+import {
+  SkyDropdownItemComponent
+} from '../dropdown-item.component';
 
 export interface SkyDropdownMenuChange {
   activeIndex?: number;

--- a/src/app/public/modules/dropdown/types/dropdown-message.ts
+++ b/src/app/public/modules/dropdown/types/dropdown-message.ts
@@ -1,4 +1,6 @@
-import { SkyDropdownMessageType } from './dropdown-message-type';
+import {
+  SkyDropdownMessageType
+} from './dropdown-message-type';
 
 export interface SkyDropdownMessage {
   type?: SkyDropdownMessageType;

--- a/src/app/public/modules/popover/fixtures/popover.component.fixture.ts
+++ b/src/app/public/modules/popover/fixtures/popover.component.fixture.ts
@@ -2,6 +2,7 @@ import {
   Component,
   ViewChild
 } from '@angular/core';
+
 import {
   Subject
 } from 'rxjs/Subject';
@@ -9,6 +10,7 @@ import {
 import {
   SkyPopoverComponent
 } from '../popover.component';
+
 import {
   SkyPopoverMessage,
   SkyPopoverMessageType

--- a/src/app/public/modules/popover/popover-adapter.service.spec.ts
+++ b/src/app/public/modules/popover/popover-adapter.service.spec.ts
@@ -10,7 +10,7 @@ import {
 
 import {
   SkyWindowRefService
-} from '@skyux/core/modules/window';
+} from '@skyux/core';
 
 import {
   SkyPopoverAdapterService

--- a/src/app/public/modules/popover/popover-adapter.service.ts
+++ b/src/app/public/modules/popover/popover-adapter.service.ts
@@ -6,7 +6,7 @@ import {
 
 import {
   SkyWindowRefService
-} from '@skyux/core/modules/window';
+} from '@skyux/core';
 
 import {
   SkyPopoverAdapterArrowCoordinates,

--- a/src/app/public/modules/popover/popover.component.ts
+++ b/src/app/public/modules/popover/popover.component.ts
@@ -1,4 +1,13 @@
 import {
+  AnimationEvent,
+  trigger,
+  state,
+  style,
+  animate,
+  transition
+} from '@angular/animations';
+
+import {
   ChangeDetectorRef,
   ChangeDetectionStrategy,
   Component,
@@ -12,29 +21,29 @@ import {
 } from '@angular/core';
 
 import {
-  AnimationEvent,
-  trigger,
-  state,
-  style,
-  animate,
-  transition
-} from '@angular/animations';
-
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/fromEvent';
-import { Subject } from 'rxjs/Subject';
-import 'rxjs/add/operator/takeUntil';
+  SkyWindowRefService
+} from '@skyux/core';
 
 import {
-  SkyWindowRefService
-} from '@skyux/core/modules/window';
+  Observable
+} from 'rxjs/Observable';
+
+import 'rxjs/add/observable/fromEvent';
+
+import {
+  Subject
+} from 'rxjs/Subject';
+
+import 'rxjs/add/operator/takeUntil';
 
 import {
   SkyPopoverAlignment,
   SkyPopoverPlacement
 } from './types';
 
-import { SkyPopoverAdapterService } from './popover-adapter.service';
+import {
+  SkyPopoverAdapterService
+} from './popover-adapter.service';
 
 @Component({
   selector: 'sky-popover',

--- a/src/app/public/modules/popover/popover.directive.spec.ts
+++ b/src/app/public/modules/popover/popover.directive.spec.ts
@@ -25,22 +25,21 @@ import {
 
 import {
   SkyWindowRefService
-} from '@skyux/core/modules/window';
-
-import {
-  SkyPopoverDirective,
-  SkyPopoverAdapterService
-} from './index';
+} from '@skyux/core';
 
 import {
   SkyPopoverTestComponent
 } from './fixtures/popover.component.fixture';
+
 import {
   SkyPopoverModule
 } from './popover.module';
+
 import {
   SkyPopoverMessageType
 } from './types/popover-message-type';
+import { SkyPopoverDirective } from './popover.directive';
+import { SkyPopoverAdapterService } from './popover-adapter.service';
 
 class MockWindowService {
   public getWindow(): any {

--- a/src/app/public/modules/popover/popover.directive.spec.ts
+++ b/src/app/public/modules/popover/popover.directive.spec.ts
@@ -38,8 +38,14 @@ import {
 import {
   SkyPopoverMessageType
 } from './types/popover-message-type';
-import { SkyPopoverDirective } from './popover.directive';
-import { SkyPopoverAdapterService } from './popover-adapter.service';
+
+import {
+  SkyPopoverDirective
+} from './popover.directive';
+
+import {
+  SkyPopoverAdapterService
+} from './popover-adapter.service';
 
 class MockWindowService {
   public getWindow(): any {

--- a/src/app/public/modules/popover/popover.directive.ts
+++ b/src/app/public/modules/popover/popover.directive.ts
@@ -15,7 +15,7 @@ import 'rxjs/add/operator/take';
 
 import {
   SkyWindowRefService
-} from '@skyux/core/modules/window';
+} from '@skyux/core';
 
 import {
   SkyPopoverAlignment,
@@ -23,9 +23,17 @@ import {
   SkyPopoverTrigger
 } from './types';
 
-import { SkyPopoverComponent } from './popover.component';
-import { SkyPopoverMessage } from './types/popover-message';
-import { SkyPopoverMessageType } from './types/popover-message-type';
+import {
+  SkyPopoverComponent
+} from './popover.component';
+
+import {
+  SkyPopoverMessage
+} from './types/popover-message';
+
+import {
+  SkyPopoverMessageType
+} from './types/popover-message-type';
 
 @Directive({
   selector: '[skyPopover]'

--- a/src/app/public/modules/popover/popover.module.ts
+++ b/src/app/public/modules/popover/popover.module.ts
@@ -1,9 +1,10 @@
 import {
-  NgModule
-} from '@angular/core';
-import {
   CommonModule
 } from '@angular/common';
+
+import {
+  NgModule
+} from '@angular/core';
 
 import {
   BrowserAnimationsModule
@@ -12,10 +13,6 @@ import {
 import {
   SkyWindowRefService
 } from '@skyux/core';
-
-import {
-  SkyI18nModule
-} from '@skyux/i18n';
 
 import {
   SkyIconModule
@@ -41,7 +38,6 @@ import {
   imports: [
     BrowserAnimationsModule,
     CommonModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyPopoversResourcesModule
   ],

--- a/src/app/public/modules/shared/popovers-resources.module.ts
+++ b/src/app/public/modules/shared/popovers-resources.module.ts
@@ -3,7 +3,8 @@ import {
 } from '@angular/core';
 
 import {
-  SKY_LIB_RESOURCES_PROVIDERS
+  SKY_LIB_RESOURCES_PROVIDERS,
+  SkyI18nModule
 } from '@skyux/i18n';
 
 import {
@@ -15,6 +16,9 @@ import {
     provide: SKY_LIB_RESOURCES_PROVIDERS,
     useClass: SkyPopoversResourcesProvider,
     multi: true
-  }]
+  }],
+  exports: [
+    SkyI18nModule
+  ]
 })
 export class SkyPopoversResourcesModule { }


### PR DESCRIPTION
Issue: https://github.com/blackbaud/skyux-popovers/issues/21

- The dropdown module needs to import the resources module (oops!). See: https://github.com/blackbaud/skyux-popovers/pull/19/files#diff-511a65915ba723ead125a60f4c4033baR52
- All other changes are import style fixes.