### PR TITLE
Fix escape closing modal when focused on dropdown

### DIFF
--- a/src/app/public/modules/popover/popover.component.spec.ts
+++ b/src/app/public/modules/popover/popover.component.spec.ts
@@ -223,7 +223,7 @@ describe('SkyPopoverComponent', () => {
 
     fixture.componentInstance.isOpen = true;
 
-    SkyAppTestUtility.fireDomEvent(fixture.nativeElement, 'keyup', {
+    SkyAppTestUtility.fireDomEvent(fixture.nativeElement, 'keydown', {
       keyboardEventInit: { key: 'Escape' }
     });
     expect(spy).toHaveBeenCalledWith();
@@ -231,7 +231,7 @@ describe('SkyPopoverComponent', () => {
     spy.calls.reset();
 
     // Should ignore other key events.
-    SkyAppTestUtility.fireDomEvent(fixture.nativeElement, 'keyup', {
+    SkyAppTestUtility.fireDomEvent(fixture.nativeElement, 'keydown', {
       keyboardEventInit: { key: 'Backspace' }
     });
     expect(spy).not.toHaveBeenCalled();

--- a/src/app/public/modules/popover/popover.component.ts
+++ b/src/app/public/modules/popover/popover.component.ts
@@ -291,7 +291,7 @@ export class SkyPopoverComponent implements OnInit, OnDestroy {
       });
 
     Observable
-      .fromEvent(hostElement, 'keyup')
+      .fromEvent(hostElement, 'keydown')
       .takeUntil(this.idled)
       .subscribe((event: KeyboardEvent) => {
         const key = event.key.toLowerCase();


### PR DESCRIPTION
Addresses: #25 

Modal acts on `keydown` while popovers was waiting for a `keyup` so when escape was pressed the modal would catch it first before the dropdown could.

Switched popovers to act on a `keydown` event instead.

Autocomplete seems to be unaffected, as it has its own event handler that acts also on `keydown` so now the autocomplete dropdown and normal dropdown should respond to escape in the same way.