### PR TITLE
[HOLD] Dropdown > Stop keyboard event propagation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4841,8 +4841,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4863,14 +4862,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4885,20 +4882,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5015,8 +5009,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5028,7 +5021,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5043,7 +5035,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5051,14 +5042,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5077,7 +5066,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5158,8 +5146,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5171,7 +5158,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5257,8 +5243,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5294,7 +5279,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5314,7 +5298,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5358,14 +5341,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/app/public/modules/dropdown/dropdown-menu.component.ts
+++ b/src/app/public/modules/dropdown/dropdown-menu.component.ts
@@ -184,11 +184,13 @@ export class SkyDropdownMenuComponent implements AfterContentInit, OnDestroy {
     if (key === 'arrowdown' || key === 'down') {
       this.focusNextItem();
       event.preventDefault();
+      event.stopPropagation();
     }
 
     if (key === 'arrowup' || key === 'up') {
       this.focusPreviousItem();
       event.preventDefault();
+      event.stopPropagation();
     }
   }
 

--- a/src/app/public/modules/dropdown/dropdown-menu.component.ts
+++ b/src/app/public/modules/dropdown/dropdown-menu.component.ts
@@ -184,7 +184,6 @@ export class SkyDropdownMenuComponent implements AfterContentInit, OnDestroy {
     if (key === 'arrowdown' || key === 'down') {
       this.focusNextItem();
       event.preventDefault();
-      event.stopPropagation();
     }
 
     if (key === 'arrowup' || key === 'up') {

--- a/src/app/public/modules/dropdown/dropdown.component.spec.ts
+++ b/src/app/public/modules/dropdown/dropdown.component.spec.ts
@@ -576,6 +576,94 @@ describe('Dropdown component', () => {
       verifyActiveMenuItemByIndex(0);
       verifyFocusedMenuItemByIndex(0, false);
     }));
+
+    it('should prevent enter key from bubbling beyond host element', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+      const buttonElem = getDropdownButtonElement();
+      const popoverElem = getPopoverContainerElement();
+
+      let numDocumentKeyEvents = 0;
+      document.addEventListener('keydown', function () {
+        numDocumentKeyEvents++;
+      });
+
+      let numDropdownKeyEvents = 0;
+      buttonElem.addEventListener('keydown', function () {
+        numDropdownKeyEvents++;
+      });
+
+      let numPopoverEvents = 0;
+      popoverElem.addEventListener('keydown', function () {
+        numPopoverEvents++;
+      });
+
+      // Open Dropdown with "enter" key.
+      dispatchKeyboardButtonClickEvent(buttonElem);
+      tick();
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      // Select first menu item with "enter" key.
+      const menuItemButton = popoverElem.querySelectorAll('button').item(0);
+      dispatchKeyboardButtonClickEvent(menuItemButton);
+      tick();
+      fixture.detectChanges();
+      tick();
+
+      expect(numDocumentKeyEvents).toEqual(0);
+      expect(numDropdownKeyEvents).toEqual(1);
+      expect(numPopoverEvents).toEqual(1);
+    }));
+
+    it('should prevent arrow keys from bubbling beyond host element', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+      const hostElem = getDropdownMenuHostElement();
+      const buttonElem = getDropdownButtonElement();
+
+      let numDocumentKeyEvents = 0;
+      document.addEventListener('keydown', function () {
+        numDocumentKeyEvents++;
+      });
+
+      let numDropdownKeyEvents = 0;
+      buttonElem.addEventListener('keydown', function () {
+        numDropdownKeyEvents++;
+      });
+
+      let numHostEvents = 0;
+      hostElem.addEventListener('keydown', function () {
+        numHostEvents++;
+      });
+
+      // Open Dropdown with "down" key.
+      SkyAppTestUtility.fireDomEvent(buttonElem, 'keydown', {
+        keyboardEventInit: { key: 'Down' }
+      });
+      tick();
+      fixture.detectChanges();
+      tick();
+
+      // Navigate down and up with arrow keys.
+      SkyAppTestUtility.fireDomEvent(hostElem, 'keydown', {
+        keyboardEventInit: { key: 'Down' }
+      });
+      tick();
+      fixture.detectChanges();
+      tick();
+      SkyAppTestUtility.fireDomEvent(hostElem, 'keydown', {
+        keyboardEventInit: { key: 'Up' }
+      });
+      tick();
+      fixture.detectChanges();
+      tick();
+
+      expect(numDocumentKeyEvents).toEqual(0);
+      expect(numDropdownKeyEvents).toEqual(1);
+      expect(numHostEvents).toEqual(2);
+    }));
   });
 
   describe('message stream', () => {

--- a/src/app/public/modules/dropdown/dropdown.component.ts
+++ b/src/app/public/modules/dropdown/dropdown.component.ts
@@ -170,6 +170,7 @@ export class SkyDropdownComponent implements OnInit, OnDestroy {
           this.windowRef.getWindow().setTimeout(() => {
             this.sendMessage(SkyDropdownMessageType.FocusTriggerButton);
           });
+          event.stopPropagation();
           break;
 
         // Allow the menu to be opened with the arrowdown key
@@ -181,6 +182,7 @@ export class SkyDropdownComponent implements OnInit, OnDestroy {
             this.sendMessage(SkyDropdownMessageType.FocusFirstItem);
             event.preventDefault();
           }
+          event.stopPropagation();
           break;
       }
 
@@ -191,6 +193,7 @@ export class SkyDropdownComponent implements OnInit, OnDestroy {
     switch (key) {
       case 'enter':
         this.isKeyboardActive = true;
+        event.stopPropagation();
         break;
 
       case 'down':
@@ -198,6 +201,7 @@ export class SkyDropdownComponent implements OnInit, OnDestroy {
         this.isKeyboardActive = true;
         this.sendMessage(SkyDropdownMessageType.Open);
         event.preventDefault();
+        event.stopPropagation();
         break;
     }
   }


### PR DESCRIPTION
This will prevent `Enter`, `ArrowUp`, and `ArrowDown` events from propagation to parent components that may also be listening for keypress events.