### PR TITLE
Fix initial placement of dropdown

### DIFF
--- a/src/app/public/modules/dropdown/dropdown.component.html
+++ b/src/app/public/modules/dropdown/dropdown.component.html
@@ -61,7 +61,7 @@
 >
   <div
     class="sky-dropdown-menu-container"
-    [hidden]="!isVisible"
+    [class.hidden]="!isVisible"
     #menuContainerElementRef
   >
     <ng-content

--- a/src/app/public/modules/dropdown/dropdown.component.scss
+++ b/src/app/public/modules/dropdown/dropdown.component.scss
@@ -36,3 +36,7 @@
 .sky-dropdown-menu-container {
   position: fixed;
 }
+
+.hidden {
+  visibility: hidden;
+}


### PR DESCRIPTION
On init, if the dropdown menu is clipped, it won't find an appropriate placement because Angular's `[hidden]` attribute _also_ sets `display: none`. Since this effectively removes the element from the DOM, the affix service has trouble finding a valid placement on init. Using our own "hidden" CSS class lets the element remain in the DOM, but invisible to the user.

![image](https://user-images.githubusercontent.com/12497062/79016430-ea74d180-7b3c-11ea-9210-85bdd400739c.png)
