### PR TITLE
Fix tab button text alignment

### DIFF
--- a/src/app/public/modules/dropdown/dropdown.component.scss
+++ b/src/app/public/modules/dropdown/dropdown.component.scss
@@ -5,6 +5,7 @@
   @include sky-btn-tab();
   @include sky-btn-tab-selected();
   max-width: 100%;
+  text-align: left;
 }
 
 .sky-dropdown-button-type-context-menu {


### PR DESCRIPTION
When the tab button has an ellipsis, the padding on the left appears inconsistent (the padding is the same, but because the text is aligned "center" it will sometimes fail visual tests).

![image](https://user-images.githubusercontent.com/12497062/80628107-de36b280-8a1e-11ea-918e-60a855864545.png)
