### PR TITLE
97 popover test fixture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8113,9 +8113,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-libs-browser": {
@@ -10218,12 +10218,12 @@
       }
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {
@@ -12070,7 +12070,6 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -12089,7 +12088,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -12122,7 +12120,6 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -12135,7 +12132,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -12191,7 +12187,6 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -12201,7 +12196,6 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -12213,7 +12207,6 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -12247,7 +12240,6 @@
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"

--- a/src/app/public/testing/dropdown/dropdown-fixture.spec.ts
+++ b/src/app/public/testing/dropdown/dropdown-fixture.spec.ts
@@ -13,13 +13,16 @@ import {
 } from '@skyux-sdk/testing';
 
 import {
-  SkyDropdownMenuChange,
-  SkyDropdownModule
+  SkyDropdownMenuChange
 } from '@skyux/popovers';
 
 import {
   SkyDropdownFixture
 } from './dropdown-fixture';
+
+import {
+  SkyDropdownTestingModule
+} from './dropdown-testing.module';
 
 const DATA_SKY_ID = 'test-dropdown';
 
@@ -107,7 +110,7 @@ describe('Dropdown fixture', () => {
         DropdownTestComponent
       ],
       imports: [
-        SkyDropdownModule
+        SkyDropdownTestingModule
       ]
     });
 

--- a/src/app/public/testing/dropdown/dropdown-fixture.spec.ts
+++ b/src/app/public/testing/dropdown/dropdown-fixture.spec.ts
@@ -125,7 +125,7 @@ describe('Dropdown fixture', () => {
     testComponent.buttonType = 'context-menu';
     testComponent.disabled = true;
     testComponent.label = 'A11y descriptor';
-    testComponent.title = 'my tile';
+    testComponent.title = 'my title';
     fixture.detectChanges();
 
     // Expect new values to be set on sky-dropdown component.

--- a/src/app/public/testing/dropdown/dropdown-fixture.spec.ts
+++ b/src/app/public/testing/dropdown/dropdown-fixture.spec.ts
@@ -1,12 +1,12 @@
 import {
-  async,
-  TestBed,
-  ComponentFixture
-} from '@angular/core/testing';
-
-import {
   Component
 } from '@angular/core';
+
+import {
+  async,
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
 
 import {
   expect

--- a/src/app/public/testing/dropdown/dropdown-testing.module.ts
+++ b/src/app/public/testing/dropdown/dropdown-testing.module.ts
@@ -1,0 +1,14 @@
+import {
+  NgModule
+} from '@angular/core';
+
+import {
+  SkyDropdownModule
+} from '@skyux/popovers';
+
+@NgModule({
+  exports: [
+    SkyDropdownModule
+  ]
+})
+export class SkyDropdownTestingModule { }

--- a/src/app/public/testing/popover/popover-fixture.spec.ts
+++ b/src/app/public/testing/popover/popover-fixture.spec.ts
@@ -1,13 +1,13 @@
 import {
-  fakeAsync,
-  TestBed,
-  ComponentFixture,
-  tick
-} from '@angular/core/testing';
-
-import {
   Component
 } from '@angular/core';
+
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick
+} from '@angular/core/testing';
 
 import {
   expect,
@@ -38,8 +38,8 @@ import {
 </button>
 
 <sky-popover
-  [popoverTitle]="popoverTitle"
   [dismissOnBlur]="dismissOnBlur"
+  [popoverTitle]="popoverTitle"
   #myPopover
 >
   {{popoverBody}}

--- a/src/app/public/testing/popover/popover-fixture.spec.ts
+++ b/src/app/public/testing/popover/popover-fixture.spec.ts
@@ -4,9 +4,7 @@ import {
 
 import {
   ComponentFixture,
-  fakeAsync,
-  TestBed,
-  tick
+  TestBed
 } from '@angular/core/testing';
 
 import {
@@ -65,19 +63,16 @@ describe('Popover fixture', () => {
     return document.querySelector('.sky-btn');
   }
 
-  function detectChangesFakeAsync(): void {
-    fixture.detectChanges();
-    tick();
-  }
-
-  function openPopover(): void {
+  function openPopover(): Promise<any> {
     expect(popoverFixture.popoverIsVisible).toEqual(false);
 
     let triggerEl = getPopoverTriggerEl();
     triggerEl.click();
-    detectChangesFakeAsync();
+    fixture.detectChanges();
 
-    expect(popoverFixture.popoverIsVisible).toEqual(true);
+    return fixture.whenStable().then(() => {
+      expect(popoverFixture.popoverIsVisible).toEqual(true);
+    });
   }
   //#endregion
 
@@ -99,7 +94,7 @@ describe('Popover fixture', () => {
     popoverFixture = new SkyPopoverFixture(fixture);
   });
 
-  it('should not expose popover properties when hidden', fakeAsync(async () => {
+  it('should not expose popover properties when hidden', async () => {
     // the popover should be hidden
     expect(popoverFixture.popoverIsVisible).toEqual(false);
 
@@ -108,9 +103,9 @@ describe('Popover fixture', () => {
     expect(popoverFixture.body).toBeUndefined();
     expect(popoverFixture.alignment).toBeUndefined();
     expect(popoverFixture.placement).toBeUndefined();
-  }));
+  });
 
-  it('should expose popover properties when visible', fakeAsync(async () => {
+  it('should expose popover properties when visible', async () => {
     // give properties non-default values
     testComponent.popoverTitle = 'my title';
     testComponent.popoverBody = 'my popover message';
@@ -126,33 +121,33 @@ describe('Popover fixture', () => {
     expect(SkyAppTestUtility.getText(popoverFixture.body)).toEqual(testComponent.popoverBody);
     expect(popoverFixture.alignment).toEqual(testComponent.popoverAlignment);
     expect(popoverFixture.placement).toEqual(testComponent.popoverPlacement);
-  }));
+  });
 
-  it('should hide by default when blur is invoked', fakeAsync(async () => {
+  it('should hide by default when blur is invoked', async () => {
     // open the popover
-    openPopover();
+    await openPopover();
 
     // blur
     await popoverFixture.blur();
-    detectChangesFakeAsync();
+    fixture.detectChanges();
 
     // expect the popover to be dismissed
     expect(popoverFixture.popoverIsVisible).toEqual(false);
-  }));
+  });
 
-  it('should honor dismissOnBlur flag', fakeAsync(async () => {
+  it('should honor dismissOnBlur flag', async () => {
     // oveerride the dismissOnBlur default
     testComponent.dismissOnBlur = false;
     fixture.detectChanges();
 
     // open the popover
-    openPopover();
+    await openPopover();
 
     // blur
     await popoverFixture.blur();
-    detectChangesFakeAsync();
+    fixture.detectChanges();
 
     // expect the popover to remain open
     expect(popoverFixture.popoverIsVisible).toEqual(true);
-  }));
+  });
 });

--- a/src/app/public/testing/popover/popover-fixture.spec.ts
+++ b/src/app/public/testing/popover/popover-fixture.spec.ts
@@ -104,7 +104,7 @@ describe('Popover fixture', () => {
     expect(popoverFixture.popoverIsVisible).toEqual(false);
 
     // expect all values to be undefined since the popover element does not exist
-    expect(popoverFixture.title).toBeUndefined();
+    expect(popoverFixture.popoverTitle).toBeUndefined();
     expect(popoverFixture.body).toBeUndefined();
     expect(popoverFixture.alignment).toBeUndefined();
     expect(popoverFixture.placement).toBeUndefined();
@@ -122,7 +122,7 @@ describe('Popover fixture', () => {
     openPopover();
 
     // expect the values to match our updates
-    expect(popoverFixture.title).toEqual(testComponent.popoverTitle);
+    expect(popoverFixture.popoverTitle).toEqual(testComponent.popoverTitle);
     expect(SkyAppTestUtility.getText(popoverFixture.body)).toEqual(testComponent.popoverBody);
     expect(popoverFixture.alignment).toEqual(testComponent.popoverAlignment);
     expect(popoverFixture.placement).toEqual(testComponent.popoverPlacement);

--- a/src/app/public/testing/popover/popover-fixture.spec.ts
+++ b/src/app/public/testing/popover/popover-fixture.spec.ts
@@ -94,7 +94,7 @@ describe('Popover fixture', () => {
     popoverFixture = new SkyPopoverFixture(fixture);
   });
 
-  it('should not expose popover properties when hidden', async () => {
+  it('should not expose popover properties when hidden', () => {
     // the popover should be hidden
     expect(popoverFixture.popoverIsVisible).toEqual(false);
 
@@ -114,7 +114,7 @@ describe('Popover fixture', () => {
     fixture.detectChanges();
 
     // the popover is closed initially, we need to open it to check values
-    openPopover();
+    await openPopover();
 
     // expect the values to match our updates
     expect(popoverFixture.popoverTitle).toEqual(testComponent.popoverTitle);

--- a/src/app/public/testing/popover/popover-fixture.spec.ts
+++ b/src/app/public/testing/popover/popover-fixture.spec.ts
@@ -121,7 +121,7 @@ describe('Popover fixture', () => {
     // the popover is closed initially, we need to open it to check values
     openPopover();
 
-    // expect all values to be undefined since the popover element does not exist
+    // expect the values to match our updates
     expect(popoverFixture.title).toEqual(testComponent.popoverTitle);
     expect(SkyAppTestUtility.getText(popoverFixture.body)).toEqual(testComponent.popoverBody);
     expect(popoverFixture.alignment).toEqual(testComponent.popoverAlignment);

--- a/src/app/public/testing/popover/popover-fixture.spec.ts
+++ b/src/app/public/testing/popover/popover-fixture.spec.ts
@@ -47,11 +47,11 @@ import {
 `
 })
 class PopoverTestComponent {
+  public dismissOnBlur: boolean;
   public popoverAlignment: string;
+  public popoverBody: string = 'popover body';
   public popoverPlacement: string;
   public popoverTitle: string = 'popover title';
-  public popoverBody: string = 'popover body';
-  public dismissOnBlur: boolean;
 }
 //#endregion Test component
 

--- a/src/app/public/testing/popover/popover-fixture.spec.ts
+++ b/src/app/public/testing/popover/popover-fixture.spec.ts
@@ -61,7 +61,7 @@ describe('Popover fixture', () => {
   let popoverFixture: SkyPopoverFixture;
 
   //#region helpers
-  function getCallerElement(): HTMLButtonElement {
+  function getPopoverTriggerEl(): HTMLButtonElement {
     return document.querySelector('.sky-btn');
   }
 
@@ -73,8 +73,8 @@ describe('Popover fixture', () => {
   function openPopover(): void {
     expect(popoverFixture.popoverIsVisible).toEqual(false);
 
-    let caller = getCallerElement();
-    caller.click();
+    let triggerEl = getPopoverTriggerEl();
+    triggerEl.click();
     detectChangesFakeAsync();
 
     expect(popoverFixture.popoverIsVisible).toEqual(true);

--- a/src/app/public/testing/popover/popover-fixture.spec.ts
+++ b/src/app/public/testing/popover/popover-fixture.spec.ts
@@ -10,6 +10,10 @@ import {
 } from '@angular/core';
 
 import {
+  NoopAnimationsModule
+} from '@angular/platform-browser/animations';
+
+import {
   expect
 } from '@skyux-sdk/testing';
 
@@ -24,8 +28,6 @@ import {
 import {
   SkyAppTestUtility
 } from '@skyux-sdk/testing';
-
-const DATA_SKY_ID = 'test-popover';
 
 //#region Test component
 @Component({
@@ -43,7 +45,6 @@ const DATA_SKY_ID = 'test-popover';
 </button>
 
 <sky-popover
-  data-sky-id="${DATA_SKY_ID}"
   [popoverTitle]="popoverTitle"
   [dismissOnBlur]="dismissOnBlur"
   #myPopover
@@ -103,7 +104,7 @@ describe('Popover fixture', () => {
     );
     testComponent = fixture.componentInstance;
     fixture.detectChanges();
-    popoverFixture = new SkyPopoverFixture(fixture, DATA_SKY_ID);
+    popoverFixture = new SkyPopoverFixture(fixture);
   });
 
   it('should not expose popover properties when hidden', fakeAsync(async () => {

--- a/src/app/public/testing/popover/popover-fixture.spec.ts
+++ b/src/app/public/testing/popover/popover-fixture.spec.ts
@@ -1,0 +1,167 @@
+import {
+  fakeAsync,
+  TestBed,
+  ComponentFixture,
+  tick
+} from '@angular/core/testing';
+
+import {
+  Component
+} from '@angular/core';
+
+import {
+  expect
+} from '@skyux-sdk/testing';
+
+import {
+  SkyPopoverModule
+} from '@skyux/popovers';
+
+import {
+  SkyPopoverFixture
+} from './popover-fixture';
+
+import {
+  SkyAppTestUtility
+} from '@skyux-sdk/testing';
+
+const DATA_SKY_ID = 'test-popover';
+
+//#region Test component
+@Component({
+  selector: 'popover-test',
+  template: `
+<button
+  class="sky-btn sky-margin-inline-compact"
+  type="button"
+  [skyPopover]="myPopover"
+  [skyPopoverAlignment]="popoverAlignment"
+  [skyPopoverPlacement]="popoverPlacement"
+  #directiveRef
+>
+  Open popover on click
+</button>
+
+<sky-popover
+  data-sky-id="${DATA_SKY_ID}"
+  [popoverTitle]="popoverTitle"
+  [dismissOnBlur]="dismissOnBlur"
+  #myPopover
+>
+  {{popoverBody}}
+</sky-popover>
+`
+})
+class PopoverTestComponent {
+  public popoverAlignment: string;
+  public popoverPlacement: string;
+  public popoverTitle: string = 'popover title';
+  public popoverBody: string = 'popover body';
+  public dismissOnBlur: boolean;
+}
+//#endregion Test component
+
+describe('Popover fixture', () => {
+  let fixture: ComponentFixture<PopoverTestComponent>;
+  let testComponent: PopoverTestComponent;
+  let popoverFixture: SkyPopoverFixture;
+
+  //#region helpers
+  function getCallerElement(): HTMLButtonElement {
+    return document.querySelector('.sky-btn');
+  }
+
+  function detectChangesFakeAsync(): void {
+    fixture.detectChanges();
+    tick();
+
+    fixture.detectChanges();
+    tick();
+  }
+
+  function openPopover(): void {
+    expect(popoverFixture.popoverIsVisible).toEqual(false);
+
+    let caller = getCallerElement();
+    caller.click();
+    detectChangesFakeAsync();
+
+    expect(popoverFixture.popoverIsVisible).toEqual(true);
+  }
+  //#endregion
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        PopoverTestComponent
+      ],
+      imports: [
+        SkyPopoverModule
+      ]
+    });
+
+    fixture = TestBed.createComponent(
+      PopoverTestComponent
+    );
+    testComponent = fixture.componentInstance;
+    fixture.detectChanges();
+    popoverFixture = new SkyPopoverFixture(fixture, DATA_SKY_ID);
+  });
+
+  it('should not expose popover properties when hidden', fakeAsync(async () => {
+    // the popover should be hidden
+    expect(popoverFixture.popoverIsVisible).toEqual(false);
+
+    // expect all values to be undefined since the popover element does not exist
+    expect(popoverFixture.title).toBeUndefined();
+    expect(popoverFixture.body).toBeUndefined();
+    expect(popoverFixture.alignment).toBeUndefined();
+    expect(popoverFixture.position).toBeUndefined();
+  }));
+
+  it('should expose popover properties when visible', fakeAsync(async () => {
+    // give properties non-default values
+    testComponent.popoverTitle = 'my title';
+    testComponent.popoverBody = 'my popover message';
+    testComponent.popoverAlignment = 'left';
+    testComponent.popoverPlacement = 'below';
+    fixture.detectChanges();
+
+    // the popover is closed initially, we need to open it to check values
+    openPopover();
+
+    // expect all values to be undefined since the popover element does not exist
+    expect(popoverFixture.title).toEqual(testComponent.popoverTitle);
+    expect(SkyAppTestUtility.getText(popoverFixture.body)).toEqual(testComponent.popoverBody);
+    expect(popoverFixture.alignment).toEqual(testComponent.popoverAlignment);
+    expect(popoverFixture.position).toEqual(testComponent.popoverPlacement);
+  }));
+
+  it('should hide by default when blur is invoked', fakeAsync(async () => {
+    // open the popover
+    openPopover();
+
+    // blur
+    await popoverFixture.blur();
+    detectChangesFakeAsync();
+
+    // expect the popover to be dismissed
+    expect(popoverFixture.popoverIsVisible).toEqual(false);
+  }));
+
+  it('should honor dismissOnBlur flag', fakeAsync(async () => {
+    // oveerride the dismissOnBlur default
+    testComponent.dismissOnBlur = false;
+    fixture.detectChanges();
+
+    // open the popover
+    openPopover();
+
+    // blur
+    await popoverFixture.blur();
+    detectChangesFakeAsync();
+
+    // expect the popover to remain open
+    expect(popoverFixture.popoverIsVisible).toEqual(true);
+  }));
+});

--- a/src/app/public/testing/popover/popover-fixture.spec.ts
+++ b/src/app/public/testing/popover/popover-fixture.spec.ts
@@ -74,9 +74,6 @@ describe('Popover fixture', () => {
   function detectChangesFakeAsync(): void {
     fixture.detectChanges();
     tick();
-
-    fixture.detectChanges();
-    tick();
   }
 
   function openPopover(): void {
@@ -96,7 +93,8 @@ describe('Popover fixture', () => {
         PopoverTestComponent
       ],
       imports: [
-        SkyPopoverModule
+        SkyPopoverModule,
+        NoopAnimationsModule
       ]
     });
 

--- a/src/app/public/testing/popover/popover-fixture.spec.ts
+++ b/src/app/public/testing/popover/popover-fixture.spec.ts
@@ -107,7 +107,7 @@ describe('Popover fixture', () => {
     expect(popoverFixture.title).toBeUndefined();
     expect(popoverFixture.body).toBeUndefined();
     expect(popoverFixture.alignment).toBeUndefined();
-    expect(popoverFixture.position).toBeUndefined();
+    expect(popoverFixture.placement).toBeUndefined();
   }));
 
   it('should expose popover properties when visible', fakeAsync(async () => {
@@ -125,7 +125,7 @@ describe('Popover fixture', () => {
     expect(popoverFixture.title).toEqual(testComponent.popoverTitle);
     expect(SkyAppTestUtility.getText(popoverFixture.body)).toEqual(testComponent.popoverBody);
     expect(popoverFixture.alignment).toEqual(testComponent.popoverAlignment);
-    expect(popoverFixture.position).toEqual(testComponent.popoverPlacement);
+    expect(popoverFixture.placement).toEqual(testComponent.popoverPlacement);
   }));
 
   it('should hide by default when blur is invoked', fakeAsync(async () => {

--- a/src/app/public/testing/popover/popover-fixture.spec.ts
+++ b/src/app/public/testing/popover/popover-fixture.spec.ts
@@ -10,24 +10,17 @@ import {
 } from '@angular/core';
 
 import {
-  NoopAnimationsModule
-} from '@angular/platform-browser/animations';
-
-import {
-  expect
+  expect,
+  SkyAppTestUtility
 } from '@skyux-sdk/testing';
-
-import {
-  SkyPopoverModule
-} from '@skyux/popovers';
 
 import {
   SkyPopoverFixture
 } from './popover-fixture';
 
 import {
-  SkyAppTestUtility
-} from '@skyux-sdk/testing';
+  SkyPopoverTestingModule
+} from './popover-testing.module';
 
 //#region Test component
 @Component({
@@ -94,8 +87,7 @@ describe('Popover fixture', () => {
         PopoverTestComponent
       ],
       imports: [
-        SkyPopoverModule,
-        NoopAnimationsModule
+        SkyPopoverTestingModule
       ]
     });
 

--- a/src/app/public/testing/popover/popover-fixture.ts
+++ b/src/app/public/testing/popover/popover-fixture.ts
@@ -12,9 +12,6 @@ import {
  * of a component, such as changing its DOM structure.
  */
 export class SkyPopoverFixture {
-  constructor(
-    private fixture: ComponentFixture<any>
-  ) { }
 
   /**
    * Indicates if the popover is open and visible.
@@ -50,6 +47,10 @@ export class SkyPopoverFixture {
   public get body(): HTMLElement {
     return this.bodyElement;
   }
+
+  constructor(
+    private fixture: ComponentFixture<any>
+  ) { }
 
   /**
    * Triggers the blur event for the popover.

--- a/src/app/public/testing/popover/popover-fixture.ts
+++ b/src/app/public/testing/popover/popover-fixture.ts
@@ -36,14 +36,14 @@ export class SkyPopoverFixture {
    * Returns the popover position if the popover is open, otherwise undefined.
    */
   public get position(): string {
-    return this.getClassValueFromPrefix('sky-popover-placement-');
+    return this.getClassSuffixByClassPrefix(this.containerElement, 'sky-popover-placement-');
   }
 
   /**
    * Returns the popover alignment if the popover is open, otherwise undefined.
    */
   public get alignment(): string {
-    return this.getClassValueFromPrefix('sky-popover-alignment-');
+    return this.getClassSuffixByClassPrefix(this.containerElement, 'sky-popover-alignment-');
   }
 
   /**
@@ -107,8 +107,18 @@ export class SkyPopoverFixture {
       : overlay.querySelector(query);
   }
 
-  private getClassValueFromPrefix(prefix: string): string {
-    let containerClasses = this.containerElement?.className.split(' ');
+  /**
+   * Searches the element's class names for a class which matches a given prefix.
+   * If a match is found, the prefix is trimmed from the class name and the suffix is returned.
+   * If no class matching the prefix is found, undefined is returned.
+   *
+   * Example:
+   *   For a class 'sky-popover-placement-right', passing the prefix 'sky-popover-placement-'
+   *   should return the value 'right'.
+   * @param prefix
+   */
+  private getClassSuffixByClassPrefix(element: HTMLElement, prefix: string): string {
+    let containerClasses = element?.className.split(' ');
     let prefixedClass = containerClasses?.find(x => x.startsWith(prefix));
 
     return !prefixedClass

--- a/src/app/public/testing/popover/popover-fixture.ts
+++ b/src/app/public/testing/popover/popover-fixture.ts
@@ -3,7 +3,8 @@ import {
 } from '@angular/core';
 
 import {
-  ComponentFixture
+  ComponentFixture,
+  tick
 } from '@angular/core/testing';
 
 import {
@@ -65,16 +66,20 @@ export class SkyPopoverFixture {
    */
   public blur(): Promise<any> {
 
-    // this.containerElement.focus();
-    // this.containerElement.blur();
-
-    // this.debugEl.nativeElement.blur();
-    // this.contentElement.blur();
-
+    // close the popover by changing focus to the body element
     SkyAppTestUtility.fireDomEvent(window.document.body, 'click');
-    // document.body.click();
 
+    /*
+      There needs to be enough time provided for the overlay to disappear before
+      returning, allowing consumers to perform assertions as expected.
+      We don't want our consumers to have to worry about any timing issues,
+      so we handle it here.
+     */
     this.fixture.detectChanges();
+    tick();
+    this.fixture.detectChanges();
+    tick();
+
     return this.fixture.whenStable();
   }
 

--- a/src/app/public/testing/popover/popover-fixture.ts
+++ b/src/app/public/testing/popover/popover-fixture.ts
@@ -40,7 +40,7 @@ export class SkyPopoverFixture {
   /**
    * Returns the popover title text if the popover is open, otherwise undefined.
    */
-  public get title(): string {
+  public get popoverTitle(): string {
     return SkyAppTestUtility.getText(this.titleElement);
   }
 

--- a/src/app/public/testing/popover/popover-fixture.ts
+++ b/src/app/public/testing/popover/popover-fixture.ts
@@ -3,8 +3,7 @@ import {
 } from '@angular/core';
 
 import {
-  ComponentFixture,
-  tick
+  ComponentFixture
 } from '@angular/core/testing';
 
 import {
@@ -65,21 +64,10 @@ export class SkyPopoverFixture {
    * Triggers the blur event for the popover.
    */
   public blur(): Promise<any> {
-
     // close the popover by changing focus to the body element
     SkyAppTestUtility.fireDomEvent(window.document.body, 'click');
 
-    /*
-      There needs to be enough time provided for the overlay to disappear before
-      returning, allowing consumers to perform assertions as expected.
-      We don't want our consumers to have to worry about any timing issues,
-      so we handle it here.
-     */
     this.fixture.detectChanges();
-    tick();
-    this.fixture.detectChanges();
-    tick();
-
     return this.fixture.whenStable();
   }
 

--- a/src/app/public/testing/popover/popover-fixture.ts
+++ b/src/app/public/testing/popover/popover-fixture.ts
@@ -1,0 +1,119 @@
+import {
+  DebugElement
+} from '@angular/core';
+
+import {
+  ComponentFixture
+} from '@angular/core/testing';
+
+import {
+  SkyAppTestUtility
+} from '@skyux-sdk/testing';
+
+/**
+ * Provides information for and interaction with a SKY UX popover component.
+ * By using the fixture API, a test insulates itself against updates to the internals
+ * of a component, such as changing its DOM structure.
+ */
+export class SkyPopoverFixture {
+  private debugEl: DebugElement;
+
+  constructor(
+    private fixture: ComponentFixture<any>,
+    skyTestId: string
+  ) {
+    this.debugEl = SkyAppTestUtility.getDebugElementByTestId(fixture, skyTestId, 'sky-popover');
+  }
+
+  /**
+   * Indicates if the popover is open and visible.
+   */
+  public get popoverIsVisible(): boolean {
+    return this.contentElement !== undefined;
+  }
+
+  /**
+   * Returns the popover position if the popover is open, otherwise undefined.
+   */
+  public get position(): string {
+    return this.getClassValueFromPrefix('sky-popover-placement-');
+  }
+
+  /**
+   * Returns the popover alignment if the popover is open, otherwise undefined.
+   */
+  public get alignment(): string {
+    return this.getClassValueFromPrefix('sky-popover-alignment-');
+  }
+
+  /**
+   * Returns the popover title text if the popover is open, otherwise undefined.
+   */
+  public get title(): string {
+    return SkyAppTestUtility.getText(this.titleElement);
+  }
+
+  /**
+   * Returns the popover body element if the popover is open, otherwise undefined.
+   */
+  public get body(): HTMLElement {
+    return this.bodyElement;
+  }
+
+  /**
+   * Triggers the blur event for the popover.
+   */
+  public blur(): Promise<any> {
+
+    // this.containerElement.focus();
+    // this.containerElement.blur();
+
+    // this.debugEl.nativeElement.blur();
+    // this.contentElement.blur();
+
+    SkyAppTestUtility.fireDomEvent(window.document.body, 'click');
+    // document.body.click();
+
+    this.fixture.detectChanges();
+    return this.fixture.whenStable();
+  }
+
+  //#region helpers
+  private get contentElement(): HTMLElement {
+    return this.queryOverlay('sky-popover-content');
+  }
+
+  private get containerElement(): HTMLElement {
+    return this.queryOverlay('.sky-popover-container');
+  }
+
+  private get titleElement(): HTMLElement {
+    return this.queryOverlay('.sky-popover-title');
+  }
+
+  private get bodyElement(): HTMLElement {
+    return this.queryOverlay('.sky-popover-body');
+  }
+
+  private getOverlay(): HTMLElement {
+    return document.querySelector('sky-overlay');
+  }
+
+  private queryOverlay(query: string): HTMLElement {
+    const overlay = this.getOverlay();
+
+    return !overlay
+      ? undefined
+      : overlay.querySelector(query);
+  }
+
+  private getClassValueFromPrefix(prefix: string): string {
+    let containerClasses = this.containerElement?.className.split(' ');
+    let prefixedClass = containerClasses?.find(x => x.startsWith(prefix));
+
+    return !prefixedClass
+      ? undefined
+      : prefixedClass.slice(prefix.length);
+  }
+  //#endregion
+}

--- a/src/app/public/testing/popover/popover-fixture.ts
+++ b/src/app/public/testing/popover/popover-fixture.ts
@@ -14,12 +14,18 @@ import {
 export class SkyPopoverFixture {
 
   /**
-   * Indicates if the popover is open and visible.
+   * Returns the popover alignment if the popover is open, otherwise undefined.
    */
-  public get popoverIsVisible(): boolean {
-    return this.contentElement !== undefined;
+  public get alignment(): string {
+    return this.getClassSuffixByClassPrefix(this.containerElement, 'sky-popover-alignment-');
   }
 
+  /**
+   * Returns the popover body element if the popover is open, otherwise undefined.
+   */
+  public get body(): HTMLElement {
+    return this.bodyElement;
+  }
   /**
    * Returns the popover position if the popover is open, otherwise undefined.
    */
@@ -28,24 +34,16 @@ export class SkyPopoverFixture {
   }
 
   /**
-   * Returns the popover alignment if the popover is open, otherwise undefined.
-   */
-  public get alignment(): string {
-    return this.getClassSuffixByClassPrefix(this.containerElement, 'sky-popover-alignment-');
-  }
-
-  /**
    * Returns the popover title text if the popover is open, otherwise undefined.
    */
   public get popoverTitle(): string {
     return SkyAppTestUtility.getText(this.titleElement);
   }
-
   /**
-   * Returns the popover body element if the popover is open, otherwise undefined.
+   * Indicates if the popover is open and visible.
    */
-  public get body(): HTMLElement {
-    return this.bodyElement;
+  public get popoverIsVisible(): boolean {
+    return this.contentElement !== undefined;
   }
 
   constructor(

--- a/src/app/public/testing/popover/popover-fixture.ts
+++ b/src/app/public/testing/popover/popover-fixture.ts
@@ -1,8 +1,4 @@
 import {
-  DebugElement
-} from '@angular/core';
-
-import {
   ComponentFixture
 } from '@angular/core/testing';
 
@@ -16,14 +12,9 @@ import {
  * of a component, such as changing its DOM structure.
  */
 export class SkyPopoverFixture {
-  private debugEl: DebugElement;
-
   constructor(
-    private fixture: ComponentFixture<any>,
-    skyTestId: string
-  ) {
-    this.debugEl = SkyAppTestUtility.getDebugElementByTestId(fixture, skyTestId, 'sky-popover');
-  }
+    private fixture: ComponentFixture<any>
+  ) { }
 
   /**
    * Indicates if the popover is open and visible.

--- a/src/app/public/testing/popover/popover-fixture.ts
+++ b/src/app/public/testing/popover/popover-fixture.ts
@@ -26,7 +26,7 @@ export class SkyPopoverFixture {
   /**
    * Returns the popover position if the popover is open, otherwise undefined.
    */
-  public get position(): string {
+  public get placement(): string {
     return this.getClassSuffixByClassPrefix(this.containerElement, 'sky-popover-placement-');
   }
 

--- a/src/app/public/testing/popover/popover-testing.module.ts
+++ b/src/app/public/testing/popover/popover-testing.module.ts
@@ -1,0 +1,22 @@
+import {
+  NgModule
+} from '@angular/core';
+
+import {
+  NoopAnimationsModule
+} from '@angular/platform-browser/animations';
+
+import {
+  SkyPopoverModule
+} from '@skyux/popovers';
+
+@NgModule({
+  exports: [
+    SkyPopoverModule,
+
+    // The noop animations module needs to be loaded last to avoid
+    // subsequent modules adding animations and overriding this.
+    NoopAnimationsModule
+  ]
+})
+export class SkyPopoverTestingModule { }

--- a/src/app/public/testing/public_api.ts
+++ b/src/app/public/testing/public_api.ts
@@ -1,5 +1,8 @@
+export * from './dropdown/dropdown-testing.module';
 export * from './dropdown/dropdown-fixture';
 export * from './dropdown/popovers-fixture-dropdown';
 export * from './dropdown/popovers-fixture-dropdown-item';
 export * from './dropdown/popovers-fixture-dropdown-menu';
+
+export * from './popover/popover-testing.module';
 export * from './popover/popover-fixture';

--- a/src/app/public/testing/public_api.ts
+++ b/src/app/public/testing/public_api.ts
@@ -2,3 +2,4 @@ export * from './dropdown/dropdown-fixture';
 export * from './dropdown/popovers-fixture-dropdown';
 export * from './dropdown/popovers-fixture-dropdown-item';
 export * from './dropdown/popovers-fixture-dropdown-menu';
+export * from './popover/popover-fixture';


### PR DESCRIPTION
This PR addresses issue #97

- Added a popover fixture
- Added SkyDropdownTestingModule and SkyPopoverTestingModule to provide hooks into consumer's test modules, allowing us to do things like turn off animations as needed.
