### PR TITLE
Release 4.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.5.1 (2021-04-15)
+
+- Fixed the service injection so that `SkyThemeService` is not required. [#144](https://github.com/blackbaud/skyux-popovers/pull/144)
+
 # 4.5.0 (2021-04-15)
 
 - Added support for SKY UX icons on dropdown component. [#141](https://github.com/blackbaud/skyux-popovers/pull/141)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/popovers",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/popovers",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "SKY UX Popovers",
   "scripts": {
     "build": "skyux build-public-library",


### PR DESCRIPTION
- Fixed the service injection so that `SkyThemeService` is not required. [#144](https://github.com/blackbaud/skyux-popovers/pull/144)
