### PR TITLE
Safe reference access on close

### DIFF
--- a/src/app/public/modules/popover/popover-content.component.ts
+++ b/src/app/public/modules/popover/popover-content.component.ts
@@ -155,6 +155,7 @@ export class SkyPopoverContentComponent implements OnInit, OnDestroy {
     this.contentTarget.createEmbeddedView(this.context.contentTemplateRef);
     this.addEventListeners();
 
+    /*istanbul ignore else*/
     if (this.themeSvc) {
       this.themeSvc.settingsChange
         .pipe(
@@ -236,6 +237,7 @@ export class SkyPopoverContentComponent implements OnInit, OnDestroy {
 
     // Let the styles render before gauging the affix dimensions.
     setTimeout(() => {
+      /*istanbul ignore next*/
       if (!this.popoverRef?.nativeElement || !this.ngUnsubscribe || this.ngUnsubscribe.isStopped) {
         return;
       }

--- a/src/app/public/modules/popover/popover-content.component.ts
+++ b/src/app/public/modules/popover/popover-content.component.ts
@@ -236,6 +236,10 @@ export class SkyPopoverContentComponent implements OnInit, OnDestroy {
 
     // Let the styles render before gauging the affix dimensions.
     setTimeout(() => {
+      if (!this.popoverRef?.nativeElement || !this.ngUnsubscribe || this.ngUnsubscribe.isStopped) {
+        return;
+      }
+
       if (!this.affixer) {
         this.setupAffixer();
       }

--- a/src/app/public/modules/popover/popover.component.ts
+++ b/src/app/public/modules/popover/popover.component.ts
@@ -204,7 +204,7 @@ export class SkyPopoverComponent implements OnDestroy {
    * @internal
    */
   public close(): void {
-    this.contentRef.close();
+    this.contentRef?.close();
   }
 
   /**
@@ -212,7 +212,7 @@ export class SkyPopoverComponent implements OnDestroy {
    * @internal
    */
   public applyFocus(): void {
-    this.contentRef.applyFocus();
+    this.contentRef?.applyFocus();
   }
 
   /**
@@ -259,10 +259,12 @@ export class SkyPopoverComponent implements OnDestroy {
         takeUntil(this.ngUnsubscribe)
       )
       .subscribe(() => {
-        this.overlayService.close(this.overlay);
-        this.overlay = undefined;
-        this.isActive = false;
-        this.popoverClosed.emit(this);
+        if (this.isActive) {
+          this.overlayService.close(this.overlay);
+          this.overlay = undefined;
+          this.isActive = false;
+          this.popoverClosed.emit(this);
+        }
       });
 
     contentRef.isMouseEnter

--- a/src/app/public/modules/popover/popover.directive.ts
+++ b/src/app/public/modules/popover/popover.directive.ts
@@ -240,7 +240,9 @@ export class SkyPopoverDirective implements OnInit, OnDestroy {
         break;
 
       case SkyPopoverMessageType.Close:
-        this.closePopover();
+        if (this.skyPopover.isActive) {
+          this.closePopover();
+        }
         break;
 
       case SkyPopoverMessageType.Reposition:


### PR DESCRIPTION
AG Grid aggressively destroys elements when swapping from render to edit mode, and when using popover, some elements are destroyed by AG Grid before popover finishes its close process.